### PR TITLE
Make processArguments() return a unix error code

### DIFF
--- a/Layout.xcodeproj/project.pbxproj
+++ b/Layout.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		01E7E04D1F1C033600B7F9DB /* LayoutNode+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E7E04C1F1C033600B7F9DB /* LayoutNode+Layout.swift */; };
 		01E7E04F1F1C057700B7F9DB /* Layout+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E7E04E1F1C057700B7F9DB /* Layout+XML.swift */; };
 		01E7E0511F1C077900B7F9DB /* LayoutError+LayoutNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E7E0501F1C077900B7F9DB /* LayoutError+LayoutNode.swift */; };
+		3583485A1F3F1EB000CFB6BB /* ProcessArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358348591F3F1EB000CFB6BB /* ProcessArgumentsTests.swift */; };
+		3583485B1F3F217200CFB6BB /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F79C1F055C260067B313 /* main.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -246,6 +248,7 @@
 		01E7E04E1F1C057700B7F9DB /* Layout+XML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Layout+XML.swift"; sourceTree = "<group>"; };
 		01E7E0501F1C077900B7F9DB /* LayoutError+LayoutNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LayoutError+LayoutNode.swift"; sourceTree = "<group>"; };
 		05DA996CC29E3F6DB7194413 /* Pods_LayoutTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LayoutTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		358348591F3F1EB000CFB6BB /* ProcessArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessArgumentsTests.swift; sourceTree = "<group>"; };
 		4118130BF7EC77593CF35CF1 /* Pods_Layout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Layout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		53F1B12A3E800D0CF1C1C2D3 /* Pods_UIDesigner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UIDesigner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8470F0AD644C109EF8FEA9C4 /* Pods_SampleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -332,8 +335,9 @@
 			isa = PBXGroup;
 			children = (
 				0105F7AB1F059A820067B313 /* FormatTests.swift */,
-				017539831F28D055005B7516 /* RenameTests.swift */,
 				0105F7AD1F059A820067B313 /* Info.plist */,
+				358348591F3F1EB000CFB6BB /* ProcessArgumentsTests.swift */,
+				017539831F28D055005B7516 /* RenameTests.swift */,
 			);
 			path = LayoutToolTests;
 			sourceTree = "<group>";
@@ -857,10 +861,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				01181E071F0EA8070011C4DE /* ExpressionParser.swift in Sources */,
+				3583485A1F3F1EB000CFB6BB /* ProcessArgumentsTests.swift in Sources */,
 				017539841F28D055005B7516 /* RenameTests.swift in Sources */,
 				017539851F28DAC5005B7516 /* Renamer.swift in Sources */,
 				0105F7B21F059CCC0067B313 /* Parser.swift in Sources */,
 				0105F7AC1F059A820067B313 /* FormatTests.swift in Sources */,
+				3583485B1F3F217200CFB6BB /* main.swift in Sources */,
 				0105F7B91F0AA7E70067B313 /* Formatter.swift in Sources */,
 				0105F7B11F059CCC0067B313 /* Common.swift in Sources */,
 				01181E0B1F0F7E530011C4DE /* Expression.swift in Sources */,

--- a/LayoutTool/main.swift
+++ b/LayoutTool/main.swift
@@ -44,10 +44,15 @@ func printHelp() {
     print("")
 }
 
-func processArguments(_ args: [String]) {
+enum ExitResult: Int32 {
+    case success = 0
+    case error = 1
+}
+
+func processArguments(_ args: [String]) -> ExitResult {
     guard args.count > 1 else {
         print("LayoutTool expects at least one argument".inRed, to: &stderr)
-        return
+        return .error
     }
     switch args[1] {
     case "help":
@@ -58,38 +63,52 @@ func processArguments(_ args: [String]) {
         let paths = Array(args.dropFirst(2))
         if paths.isEmpty {
             print("format command expects one or more file paths as input".inRed, to: &stderr)
-            return
+            return .error
         }
-        for error in format(paths) {
+        let errors = format(paths)
+        for error in errors {
             print("\(error)".inRed, to: &stderr)
+        }
+        if !errors.isEmpty {
+            return .error
         }
     case "list":
         let paths = Array(args.dropFirst(2))
         if paths.isEmpty {
             print("list command expects one or more file paths to search".inRed, to: &stderr)
-            return
+            return .error
         }
-        for error in list(paths) {
+        let errors = list(paths)
+        for error in errors {
             print("\(error)".inRed, to: &stderr)
+        }
+        if !errors.isEmpty {
+            return .error
         }
     case "rename":
         var paths = Array(args.dropFirst(2))
         guard let new = paths.popLast(), let old = paths.popLast(), !new.contains("/"), !old.contains("/") else {
             print("rename command expects a symbol name and a replacement".inRed, to: &stderr)
-            return
+            return .error
         }
         if paths.isEmpty {
             print("rename command expects one or more file paths to search".inRed, to: &stderr)
-            return
+            return .error
         }
-        for error in rename(old, to: new, in: paths) {
+        let errors = rename(old, to: new, in: paths)
+        for error in errors {
             print("\(error)".inRed, to: &stderr)
+        }
+        if !errors.isEmpty {
+            return .error
         }
     case let arg:
         print("`\(arg)` is not a valid command".inRed, to: &stderr)
-        return
+        return .error
     }
+    return .success
 }
 
-// Pass in arguments
-processArguments(CommandLine.arguments)
+// Pass in arguments and exit
+let result = processArguments(CommandLine.arguments)
+exit(result.rawValue)

--- a/LayoutTool/main.swift
+++ b/LayoutTool/main.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /// The current LayoutTool version
-let version = "0.3"
+let version = "0.4"
 
 extension String {
     var inDefault: String { return "\u{001B}[39m\(self)" }

--- a/LayoutToolTests/ProcessArgumentsTests.swift
+++ b/LayoutToolTests/ProcessArgumentsTests.swift
@@ -1,0 +1,16 @@
+//  Copyright © 2017 Schibsted. All rights reserved.
+
+import XCTest
+
+class ProcessArgumentsTests: XCTestCase {
+
+    func testReturnsSuccessCodeForExpectedInput() {
+        XCTAssertEqual(processArguments(["LayoutTool", "version"]), .success)
+    }
+
+    func testReturnsErrorCodeWhenErrorsOccur() {
+        XCTAssertEqual(processArguments(["LayoutTool"]), .error)
+        XCTAssertEqual(processArguments(["LayoutTool", "format"]), .error)
+    }
+    
+}


### PR DESCRIPTION
Implemented an idea behind #21.

The code I've added is duplicated, and I see a possible abstraction that would remove the repetition. 

However I think it's a valuable addition already:

<img width="1072" alt="screen shot 2017-08-12 at 14 05 07" src="https://user-images.githubusercontent.com/318902/29240560-20682752-7f68-11e7-9aee-54a5ac61b5db.png">

Also I've added some happy-path tests to see if it works at all.

@nicklockwood Please let me know if you'd like me to spend some more time for refactoring the duplication.