### PR TITLE
Replaced state property with a setter method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: objective-c
 osx_image: xcode8.3
+
 script: xcodebuild test -project Layout.xcodeproj -scheme Layout -destination 'platform=iOS Simulator,name=iPhone 7 Plus,OS=10.3.1'
 script: xcodebuild test -project Layout.xcodeproj -scheme LayoutTool -sdk macosx
+
+script: xcodebuild -project Layout.xcodeproj -scheme SampleApp -sdk iphonesimulator
+script: xcodebuild -project Layout.xcodeproj -scheme Sandbox -sdk iphonesimulator
+script: xcodebuild -project Layout.xcodeproj -scheme UIDesigner -sdk iphonesimulator
 

--- a/SampleApp/BoxesViewController.swift
+++ b/SampleApp/BoxesViewController.swift
@@ -7,13 +7,13 @@ class BoxesViewController: UIViewController {
 
     var toggled = false {
         didSet {
-            layoutNode?.state = ["isToggled": toggled]
+            layoutNode?.setState(["isToggled": toggled])
         }
     }
 
     var layoutNode: LayoutNode? {
         didSet {
-            layoutNode?.state = ["isToggled": toggled]
+            layoutNode?.setState(["isToggled": toggled])
         }
     }
 

--- a/SampleApp/CollectionViewController.swift
+++ b/SampleApp/CollectionViewController.swift
@@ -32,11 +32,11 @@ class CollectionViewController: UIViewController, UICollectionViewDelegate, UICo
         let node = collectionView.dequeueReusableCellNode(withIdentifier: identifier, for: indexPath)
         let image = images[indexPath.row % images.count]!
 
-        node.state = [
+        node.setState([
             "row": indexPath.row,
             "image": image,
             "whiteImage": image.withRenderingMode(.alwaysOriginal),
-        ]
+        ])
 
         return node.view as! UICollectionViewCell
     }

--- a/SampleApp/TableViewController.swift
+++ b/SampleApp/TableViewController.swift
@@ -37,11 +37,11 @@ class TableViewController: UIViewController, UITableViewDataSource, UITableViewD
         let node = tableView.dequeueReusableCellNode(withIdentifier: identifier, for: indexPath)
         let image = images[indexPath.row % images.count]!
 
-        node.state = [
+        node.setState([
             "row": indexPath.row,
             "image": image,
             "whiteImage": image.withRenderingMode(.alwaysOriginal),
-        ]
+        ])
 
         return node.view as! UITableViewCell
     }


### PR DESCRIPTION
This PR adds a new `setState(_:)` method to `LayoutNode`, and deprecates the `state` property.

# Rationale:

Layout allows state to be set either as a dictionary or a struct. Internally, state is always converted to a dictionary of variables using `Mirror`. Having state as a public variable means we must preserve the original struct value in addition to the dictionary form so that it can be read later, which imposes a storage overhead as well as additional comparison costs each time it is updated.

It also means you can't make use of the feature of updating just one or two properties if you are using a struct - you must always set the entire struct object since we cannot recompose the original struct from keys (the `Mirror` API is read-only).

Switching to a `setState(_:)` method makes the state property "write-only", allowing more flexibility for the internal implementation.