### PR TITLE
`update()` method no longer throws an Error

### DIFF
--- a/Layout/LayoutNode.swift
+++ b/Layout/LayoutNode.swift
@@ -144,7 +144,7 @@ public class LayoutNode: NSObject {
         if let change = change, let old = change[.oldKey] as? CGRect, old.size == _view.bounds.size {
             return
         }
-        attempt(update)
+        update()
     }
 
     @objc private func contentSizeChanged() {
@@ -152,7 +152,7 @@ public class LayoutNode: NSObject {
             return
         }
         cleanUp()
-        attempt(update)
+        update()
     }
 
     // Create the node using a UIView or UIViewController subclass
@@ -293,7 +293,7 @@ public class LayoutNode: NSObject {
     }
 
     private var _unhandledError: LayoutError?
-    private func throwUnhandledError() throws {
+    func throwUnhandledError() throws {
         try _unhandledError.map {
             if $0.isTransient {
                 _unhandledError = nil
@@ -573,7 +573,7 @@ public class LayoutNode: NSObject {
             addChild(try LayoutNode(layout: child))
         }
         if _setupComplete, _view.window != nil || _owner != nil {
-            try update()
+            update()
         }
     }
 
@@ -1396,9 +1396,11 @@ public class LayoutNode: NSObject {
 
     /// Re-evaluates all expressions for the node and its children
     /// Note: thrown error is always a LayoutError
-    public func update() throws {
-        try updateValues(animated: false)
-        try updateFrame()
+    public func update() {
+        attempt {
+            try updateValues(animated: false)
+            try updateFrame()
+        }
     }
 
     // MARK: binding
@@ -1416,9 +1418,8 @@ public class LayoutNode: NSObject {
         viewController.view.addSubview(view)
         if _view.frame != viewController.view.bounds {
             _view.frame = viewController.view.bounds
-            try throwUnhandledError()
         } else {
-            try update()
+            update()
         }
     }
 
@@ -1444,7 +1445,7 @@ public class LayoutNode: NSObject {
             }
         }
         view.addSubview(_view)
-        try update()
+        update()
     }
 
     /// Unmounts and unbinds the node from its owner

--- a/Layout/LayoutViewController.swift
+++ b/Layout/LayoutViewController.swift
@@ -44,11 +44,7 @@ open class LayoutViewController: UIViewController, LayoutLoading {
             if self.view.bounds != view.bounds {
                 view.frame = self.view.bounds
             } else {
-                do {
-                    try layoutNode?.update()
-                } catch {
-                    layoutError(LayoutError(error, for: layoutNode))
-                }
+                layoutNode?.update()
             }
         }
     }

--- a/Layout/UICollectionView+Layout.swift
+++ b/Layout/UICollectionView+Layout.swift
@@ -126,7 +126,7 @@ extension UICollectionView {
         didSet {
             if oldValue != contentSize, let layoutNode = layoutNode {
                 let contentOffset = self.contentOffset
-                try? layoutNode.update()
+                layoutNode.update()
                 self.contentOffset = contentOffset
             }
         }

--- a/Layout/UITableView+Layout.swift
+++ b/Layout/UITableView+Layout.swift
@@ -134,7 +134,7 @@ extension UITableView {
         didSet {
             if oldValue != contentSize, let layoutNode = layoutNode {
                 let contentOffset = self.contentOffset.y
-                try? layoutNode.update()
+                layoutNode.update()
                 if contentOffset >= 0 {
                     self.contentOffset.y = contentOffset
                 }

--- a/LayoutTests/LayoutExpressionTests.swift
+++ b/LayoutTests/LayoutExpressionTests.swift
@@ -269,7 +269,8 @@ class LayoutExpressionTests: XCTestCase {
             constants: ["foo": "Not a color"],
             expressions: ["backgroundColor": "{foo}"]
         )
-        XCTAssertThrowsError(try node.update()) { error in
+        node.update()
+        XCTAssertThrowsError(try node.throwUnhandledError()) { error in
             XCTAssertTrue("\(error)".contains("String"))
             XCTAssertTrue("\(error)".contains("UIColor"))
             XCTAssertTrue("\(error)".contains("backgroundColor"))

--- a/LayoutTests/LayoutFrameTests.swift
+++ b/LayoutTests/LayoutFrameTests.swift
@@ -172,7 +172,7 @@ class LayoutFrameTests: XCTestCase {
                 ),
             ]
         )
-        XCTAssertNoThrow(try node.update())
+        node.update()
         XCTAssertEqual(node.frame.size, CGSize(width: 150, height: 50))
         XCTAssertEqual(node.children[0].frame.size, CGSize(width: 75, height: 20))
     }
@@ -199,7 +199,7 @@ class LayoutFrameTests: XCTestCase {
                 ),
             ]
         )
-        XCTAssertNoThrow(try node.update())
+        node.update()
         XCTAssertEqual(node.frame.size, CGSize(width: 150, height: 50))
         XCTAssertEqual(node.children[0].frame.size, CGSize(width: 150, height: 20))
     }

--- a/LayoutTests/LayoutNodeTests.swift
+++ b/LayoutTests/LayoutNodeTests.swift
@@ -121,7 +121,7 @@ class LayoutNodeTests: XCTestCase {
         let node = LayoutNode(view: UIView(), expressions: ["width": "layer.contents == nil ? 5 : 10"])
         let errors = node.validate()
         XCTAssertEqual(errors.count, 0)
-        try! node.update()
+        node.update()
         XCTAssertNil(node.view.layer.contents)
         XCTAssertEqual(node.view.frame.width, 5)
     }

--- a/LayoutTests/SelectorExpressionTests.swift
+++ b/LayoutTests/SelectorExpressionTests.swift
@@ -25,7 +25,7 @@ class SelectorExpressionTests: XCTestCase {
 
     func testSetCustomSelector() {
         let node = LayoutNode(view: TestView(), expressions: ["action": "foo:"])
-        XCTAssertNoThrow(try node.update())
+        node.update()
         XCTAssertNotNil(node.view.action)
     }
 }

--- a/PerformanceTests/PerformanceTests.swift
+++ b/PerformanceTests/PerformanceTests.swift
@@ -66,7 +66,7 @@ class PerformanceTests: XCTestCase {
         measure {
             view.frame.size.width += 1
             view.frame.size.height -= 1
-            try! rootNode.update()
+            rootNode.update()
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1007,23 +1007,23 @@ If you would prefer not to use either the `LayoutViewController` base class or `
 
 ```swift
 class MyViewController: UIViewController {
-    var layoutNode: LayoutNode!
+    var layoutNode: LayoutNode?
 
     public override func viewDidLoad() {
         super.viewDidLoad()
 
         // Create a layout node from and XML file or data object
-        self.layoutNode = LayoutNode.with(xmlData: ...)
+        self.layoutNode = try? LayoutNode.with(xmlData: ...)
 
         // Mount it
-        try! self.layoutNode.mount(in: self)
+        try? self.layoutNode?.mount(in: self)
     }
 
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
 
         // Ensure layout is resized after screen rotation, etc
-        try! self.layoutNode.update()
+        self.layoutNode?.update()
     }
 }
 ```
@@ -1031,7 +1031,7 @@ This method of integration does not provide the automatic live reloading feature
 
 If you are using some fancy architecture like [Viper](https://github.com/MindorksOpenSource/iOS-Viper-Architecture) that splits up view controllers into sub-components, you may find that you need to bind a `LayoutNode` to something other than a `UIView` or `UIViewController` subclass. In that case you can use the `bind(to:)` method, which will connect the node's outlets, actions and delegates to the specified owner object, but won't attempt to mount the view or view controllers.
 
-The `mount(in:)`, `bind(to:)` and `update()` methods may each throw an error if there is a problem with your XML markup, or in an expression's syntax or logic.
+The `mount(in:)` and `bind(to:)` methods may each throw an error if there is a problem with your XML markup, or in an expression's syntax or symbols.
 
 These errors are not expected to occur in a correctly implemented layout - they typically only happen if you have made a mistake in your code - so for release builds it should be OK to suppress them with `try!` or `try?` (assuming you've tested your app properly before releasing it!).
 


### PR DESCRIPTION
This PR removes `throws` from the `LayoutNode.update()` method.

# Rationale:

Errors in Layout generally break down into two types:

1. XML syntax errors, or other serious errors that make it impossible to load the view hierarchy
2. Expression logic errors such as mistyped or misnamed variables, type mismatches, unexpected nil, etc.

Errors in the former category are typically generated when calling `LayoutNode.with(xmlData:)` or `LayoutNode.mount()` or `LayoutNode.bind()`

These methods are called internally by the Layout framework if you are using `LayoutViewController`, in which case Layout already has all the necessary context to handle the error by displaying a Red Box. But if you are creating a `LayoutNode` manually then you'll need to handle the error yourself because Layout won't have a reference to a `LayoutViewController` in which to display the error. For this reason, it's useful if they throw an error in the event of a failure.

The other errors may be deferred until the first time the layout is rendered, as state or constants may bot be available at creation time, so throwing errors relating to missing constants too early would lead to false positives. These errors will be thrown when `setState()` or `update()` is first called.

The `setState()` and `update()` methods  are usually called manually by the developer, typically inside a delegate or action method in a `UIViewController`. If these produce an error, the `LayoutNode` itself probably has enough context to bubble this up to the nearest `LayoutViewController` for display in a red Box, but this info isn't exposed to the developer.

There is no public mechanism for a developer to display the Red Box themselves, so if they call `update()` and get an error, they typically have to either discard it, or crash. Doing anything else (such as creating their own error/retry dialog) would be a lot of work.

It therefore makes more sense for `update()` not to throw, but instead to handle the error internally and display it in the Red Box where possible This is already the case for `setState()`, since it was previously implemented as a property, which cannot throw.

# Alternatives considered:

The `update()` and `setState()` methods could both be marked as `throws`, but be designed to detect if the `LayoutNode` is inside a `LayoutViewController` and display a Red Box *as well as* throwing an error.

This would be confusing though, as the user wouldn't know if they needed to handle the error or not.  It would also mean writing `try?` to ignore the error in most cases, which is generally a bad practice.

Another option is that `update()` and `setState()` could be marked as `throws`, but *only* throw an error if no Red Box interface is available.

This would also be confusing though, as the user would have to have a deep understanding of the underlying mechanism in order to know when it's safe to ignore errors and when it isn't. It would also mean writing `try!` everywhere to indicate that no error is expected be thrown, which maybe even worse than using `try?`.

Yet another option would be to try to make the Red Box mechanism more public, perhaps with a global `RedBox.showIfThrows(_ closure: () throws -> Void)` mechanism. But this would make using `setState()` more cumbersome in the typical case, as you'd have to write something like `RedBox.showIfThrows(layoutNode.update)` instead of just `layoutNode.update()` (and it would be even worse for `setState()`)