### PR TITLE
Added support for // comments in expressions

### DIFF
--- a/Layout/LayoutExpression.swift
+++ b/Layout/LayoutExpression.swift
@@ -142,7 +142,7 @@ struct LayoutExpression {
                  for node: LayoutNode) {
         do {
             self.init(
-                anyExpression: try parseExpression(anyExpression),
+                anyExpression: try parseExpression(anyExpression).expression,
                 type: type,
                 nullable: nullable,
                 symbols: symbols,
@@ -315,7 +315,7 @@ struct LayoutExpression {
                 switch part {
                 case let .expression(parsedExpression):
                     let expression = LayoutExpression(
-                        anyExpression: parsedExpression,
+                        anyExpression: parsedExpression.expression,
                         type: RuntimeType(Any.self),
                         nullable: true,
                         for: node

--- a/Layout/LayoutNode.swift
+++ b/Layout/LayoutNode.swift
@@ -657,7 +657,7 @@ public class LayoutNode: NSObject {
         }
         try completeSetup()
         for (symbol, string) in expressions {
-            var expression: LayoutExpression
+            var expression: LayoutExpression!
             var isViewControllerExpression = false
             var isViewExpression = false
             switch symbol {
@@ -708,6 +708,9 @@ public class LayoutNode: NSObject {
                 } else {
                     expression = LayoutExpression(expression: string, type: type, for: self)
                 }
+            }
+            guard expression != nil else {
+                continue
             }
             // Only set constant values once
             if expression.symbols.isEmpty {

--- a/Layout/UICollectionView+Layout.swift
+++ b/Layout/UICollectionView+Layout.swift
@@ -25,12 +25,11 @@ extension UICollectionView {
 
     open override class func create(with node: LayoutNode) throws -> UICollectionView {
         let layout: UICollectionViewLayout
-        if let expression = node.expressions["collectionViewLayout"] {
-            let layoutExpression = LayoutExpression(
-                expression: expression,
-                type: RuntimeType(UICollectionViewLayout.self),
-                for: node
-            )
+        if let expression = node.expressions["collectionViewLayout"], let layoutExpression = LayoutExpression(
+            expression: expression,
+            type: RuntimeType(UICollectionViewLayout.self),
+            for: node
+        ) {
             layout = try layoutExpression.evaluate() as! UICollectionViewLayout
         } else {
             layout = defaultLayout(for: node)
@@ -79,12 +78,11 @@ extension UICollectionView {
             // TODO: it would be better if we never added cell template nodes to
             // the hierarchy, rather than having to remove them afterwards
             node.removeFromParent()
-            if let expression = node.expressions["reuseIdentifier"] {
-                let idExpression = LayoutExpression(
-                    expression: expression,
-                    type: RuntimeType(String.self),
-                    for: node
-                )
+            if let expression = node.expressions["reuseIdentifier"], let idExpression = LayoutExpression(
+                expression: expression,
+                type: RuntimeType(String.self),
+                for: node
+            ) {
                 if let reuseIdentifier = try? idExpression.evaluate() as! String {
                     registerLayout(Layout(node), forCellReuseIdentifier: reuseIdentifier)
                 }
@@ -158,12 +156,11 @@ extension UICollectionView: LayoutDelegate {
 extension UICollectionViewController {
     open override class func create(with node: LayoutNode) throws -> UICollectionViewController {
         let layout: UICollectionViewLayout
-        if let expression = node.expressions["collectionViewLayout"] {
-            let layoutExpression = LayoutExpression(
-                expression: expression,
-                type: RuntimeType(UICollectionViewLayout.self),
-                for: node
-            )
+        if let expression = node.expressions["collectionViewLayout"], let layoutExpression = LayoutExpression(
+            expression: expression,
+            type: RuntimeType(UICollectionViewLayout.self),
+            for: node
+        ) {
             layout = try layoutExpression.evaluate() as! UICollectionViewLayout
         } else {
             layout = UICollectionView.defaultLayout(for: node)

--- a/Layout/UITableView+Layout.swift
+++ b/Layout/UITableView+Layout.swift
@@ -23,8 +23,8 @@ extension UITableView {
 
     open override class func create(with node: LayoutNode) throws -> UITableView {
         var style = UITableViewStyle.plain
-        if let expression = node.expressions["style"] {
-            let styleExpression = LayoutExpression(expression: expression, type: tableViewStyle, for: node)
+        if let expression = node.expressions["style"],
+            let styleExpression = LayoutExpression(expression: expression, type: tableViewStyle, for: node) {
             style = try styleExpression.evaluate() as! UITableViewStyle
         }
         let tableView = self.init(frame: .zero, style: style)
@@ -76,12 +76,11 @@ extension UITableView {
             // TODO: it would be better if we never added cell template nodes to
             // the hierarchy, rather than having to remove them afterwards
             node.removeFromParent()
-            if let expression = node.expressions["reuseIdentifier"] {
-                let idExpression = LayoutExpression(
-                    expression: expression,
-                    type: RuntimeType(String.self),
-                    for: node
-                )
+            if let expression = node.expressions["reuseIdentifier"], let idExpression = LayoutExpression(
+                expression: expression,
+                type: RuntimeType(String.self),
+                for: node
+            ) {
                 if let reuseIdentifier = try? idExpression.evaluate() as! String {
                     if node.viewClass is UITableViewCell.Type {
                         registerLayout(Layout(node), forReuseIdentifier: reuseIdentifier, key: &cellDataKey)
@@ -146,8 +145,8 @@ extension UITableView {
 extension UITableViewController {
     open override class func create(with node: LayoutNode) throws -> UITableViewController {
         var style = UITableViewStyle.plain
-        if let expression = node.expressions["style"] ?? node.expressions["tableView.style"] {
-            let styleExpression = LayoutExpression(expression: expression, type: tableViewStyle, for: node)
+        if let expression = node.expressions["style"] ?? node.expressions["tableView.style"],
+            let styleExpression = LayoutExpression(expression: expression, type: tableViewStyle, for: node) {
             style = try styleExpression.evaluate() as! UITableViewStyle
         }
         let viewController = self.init(style: style)
@@ -424,8 +423,8 @@ extension UITableViewHeaderFooterView {
 
     open override class func create(with node: LayoutNode) throws -> UITableViewHeaderFooterView {
         var reuseIdentifier: String?
-        if let expression = node.expressions["reuseIdentifier"] {
-            let idExpression = LayoutExpression(expression: expression, type: RuntimeType(String.self), for: node)
+        if let expression = node.expressions["reuseIdentifier"],
+            let idExpression = LayoutExpression(expression: expression, type: RuntimeType(String.self), for: node) {
             reuseIdentifier = try idExpression.evaluate() as? String
         }
         let view = self.init() // Workaround for `self.init(reuseIdentifier:)` causing build failure
@@ -501,13 +500,13 @@ extension UITableViewCell {
 
     open override class func create(with node: LayoutNode) throws -> UITableViewCell {
         var style = UITableViewCellStyle.default
-        if let expression = node.expressions["style"] {
-            let styleExpression = LayoutExpression(expression: expression, type: tableViewCellStyle, for: node)
+        if let expression = node.expressions["style"],
+            let styleExpression = LayoutExpression(expression: expression, type: tableViewCellStyle, for: node) {
             style = try styleExpression.evaluate() as! UITableViewCellStyle
         }
         var reuseIdentifier: String?
-        if let expression = node.expressions["reuseIdentifier"] {
-            let idExpression = LayoutExpression(expression: expression, type: RuntimeType(String.self), for: node)
+        if let expression = node.expressions["reuseIdentifier"],
+            let idExpression = LayoutExpression(expression: expression, type: RuntimeType(String.self), for: node) {
             reuseIdentifier = try idExpression.evaluate() as? String
         }
         let cell: UITableViewCell

--- a/LayoutTests/LayoutExpressionTests.swift
+++ b/LayoutTests/LayoutExpressionTests.swift
@@ -42,11 +42,11 @@ class LayoutExpressionTests: XCTestCase {
     }
 
     func testParseEmptyExpression() {
-        XCTAssertThrowsError(try parseExpression(""))
+        XCTAssertNoThrow(try parseExpression(""))
     }
 
     func testParseExpressionWithEmptyBraces() {
-        XCTAssertThrowsError(try parseExpression("{}"))
+        XCTAssertNoThrow(try parseExpression("{}"))
     }
 
     func testParseExpressionOpeningBrace() {
@@ -163,7 +163,7 @@ class LayoutExpressionTests: XCTestCase {
     }
 
     func testParseStringExpressionWithEmptyBraces() {
-        XCTAssertThrowsError(try parseStringExpression("{}"))
+        XCTAssertNoThrow(try parseStringExpression("{}"))
     }
 
     func testParseStringExpressionOpeningBrace() {

--- a/LayoutTests/LayoutExpressionTests.swift
+++ b/LayoutTests/LayoutExpressionTests.swift
@@ -220,6 +220,48 @@ class LayoutExpressionTests: XCTestCase {
         XCTAssertNil(expression.error)
     }
 
+    // MARK: Expression comments
+
+    func testParseExpressionWithCommentWithoutBraces() {
+        let expression = try? parseExpression("4 + 5 // hello")
+        XCTAssertNotNil(expression)
+        XCTAssertEqual(expression?.symbols, [.infix("+")])
+        XCTAssertEqual(expression?.description, "4 + 5 // hello")
+    }
+
+    func testParseExpressionWithCommentWithBraces() {
+        let expression = try? parseExpression("{4 + 5 // hello}")
+        XCTAssertNotNil(expression)
+        XCTAssertEqual(expression?.symbols, [.infix("+")])
+        XCTAssertEqual(expression?.description, "4 + 5 // hello")
+    }
+
+    func testParseStringExpressionWithComment() {
+        guard let parts = try? parseStringExpression("foo {4 + 5 // hello } bar") else {
+            XCTFail()
+            return
+        }
+        guard parts.count == 3 else {
+            XCTFail()
+            return
+        }
+        guard case .string("foo ") = parts[0] else {
+            XCTFail()
+            return
+        }
+        guard case let .expression(expression) = parts[1] else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(expression.symbols, [.infix("+")])
+        XCTAssertEqual(expression.description, "4 + 5 // hello")
+        XCTAssertNil(expression.error)
+        guard case .string(" bar") = parts[2] else {
+            XCTFail()
+            return
+        }
+    }
+
     // MARK: Integration tests
 
     func testOptionalBracesInNumberExpression() {

--- a/LayoutTool/Renamer.swift
+++ b/LayoutTool/Renamer.swift
@@ -122,7 +122,7 @@ private func rename(_ old: String, to new: String, in parts: [ParsedExpressionPa
     return changed ? parts.joined() : nil
 }
 
-private func rename(_ old: String, to new: String, in expression: ParsedExpression) -> String? {
+private func rename(_ old: String, to new: String, in expression: ParsedLayoutExpression) -> String? {
     guard expression.symbols.contains(.variable(old)) else {
         return nil
     }


### PR DESCRIPTION
This PR adds a workaround for the lack of support for inter-attribute comments in XML by allowing C++-style trailing // comments inside expressions. This is useful both for documentation purposes, but also for quickly commenting out an attribute during development.

For example, we'd like to be able to do this:

```xml
<UIView
    <!-- backgroundColor="red" -->
    left="20"
/>
```

But that's not permitted in XML, so instead we can now do this:

```xml
<UIView
    backgroundColor="// red"
    left="20"
/>
```

A slightly rough edge is for String expressions. Since the body of a string expression is treated as a literal, you cannot simply add // or that will be treated as a part of the literal string. Instead you must first add { ... } around the string body, then add the //:

```xml
<UILabel
    text="{ // Lorem ipsum }"
/>
```

The PR is split into two commits - the first adds support for comments in expressions. The second makes it possible to have empty expressions, which were previously an error (this is necessary to support commenting-out an expression, though it also allows comment-less expressions to be empty as a side-effect, which should maybe still be an error)