### PR TITLE
Improve scrolling performance for self sizing cells

### DIFF
--- a/Layout/LayoutNode.swift
+++ b/Layout/LayoutNode.swift
@@ -124,7 +124,7 @@ public class LayoutNode: NSObject {
             stopObserving()
         } else if !_observing, parent == nil {
             NotificationCenter.default.addObserver(self, selector: #selector(contentSizeChanged), name: .UIContentSizeCategoryDidChange, object: nil)
-            addObserver(self, forKeyPath: "_view.frame", options: [], context: nil)
+            addObserver(self, forKeyPath: "_view.frame", options: .old, context: nil)
             addObserver(self, forKeyPath: "_view.bounds", options: .old, context: nil)
             _observing = true
         }
@@ -140,12 +140,12 @@ public class LayoutNode: NSObject {
     }
 
     public override func observeValue(
-        forKeyPath keyPath: String?,
+        forKeyPath _: String?,
         of _: Any?,
         change: [NSKeyValueChangeKey: Any]?,
         context _: UnsafeMutableRawPointer?
     ) {
-        if let change = change, let old = change[.oldKey] as? CGRect, old.size == _view?.bounds.size {
+        if let change = change, let old = change[.oldKey] as? CGRect, old.size.isNearlyEqual(to: _view?.bounds.size) {
             return
         }
         update()

--- a/Layout/Utilities.swift
+++ b/Layout/Utilities.swift
@@ -20,3 +20,13 @@ private let classPrefix = (Bundle.main.object(forInfoDictionaryKey: "CFBundleNam
 func classFromString(_ name: String) -> AnyClass? {
     return NSClassFromString(name) ?? NSClassFromString("\(classPrefix).\(name)")
 }
+
+private let precision: CGFloat = 0.001
+
+extension CGSize {
+
+    func isNearlyEqual(to other: CGSize?) -> Bool {
+        guard let other = other else { return false }
+        return (fabs(width - other.width) <= precision) && (fabs(height - other.height) <= precision)
+    }
+}


### PR DESCRIPTION
When observeValue is called two issues were happening that caused the node to be unnecessarily updated:
1) When listening for changes to the `frame`, the old value was not present
2) The comparison between old and new sizes was unsuccessful because of floating point inaccuracies