### PR TITLE
Added macros

### DIFF
--- a/Layout/Layout.swift
+++ b/Layout/Layout.swift
@@ -9,6 +9,7 @@ struct Layout {
     var outlet: String?
     var expressions: [String: String]
     var parameters: [String: RuntimeType]
+    var macros: [String: String]
     var children: [Layout]
     var xmlPath: String?
     var templatePath: String?

--- a/Layout/LayoutLoader.swift
+++ b/Layout/LayoutLoader.swift
@@ -26,14 +26,19 @@ private extension Layout {
             expressions[key] = value
         }
         var parameters = self.parameters
-        for (key, value) in layout.parameters {
+        for (key, value) in layout.parameters { // TODO: what about collisions?
             parameters[key] = value
+        }
+        var macros = self.macros
+        for (key, value) in layout.macros { // TODO: what about collisions?
+            macros[key] = value
         }
         return Layout(
             className: layout.className,
             outlet: layout.outlet ?? outlet,
             expressions: expressions,
             parameters: parameters,
+            macros: macros,
             children: children + layout.children,
             xmlPath: layout.xmlPath,
             templatePath: templatePath,

--- a/Layout/LayoutNode+Layout.swift
+++ b/Layout/LayoutNode+Layout.swift
@@ -25,6 +25,7 @@ extension LayoutNode {
             }
         )
         _parameters = layout.parameters
+        _macros = layout.macros
         guard let xmlPath = layout.xmlPath else {
             return
         }
@@ -60,6 +61,7 @@ extension Layout {
             outlet: node.outlet,
             expressions: node._originalExpressions,
             parameters: node._parameters,
+            macros: node._macros,
             children: node.children.map(Layout.init(_:)),
             xmlPath: nil, // TODO: what if the layout is currently loading this? Race condition!
             templatePath: nil,

--- a/Layout/XMLNode+Layout.swift
+++ b/Layout/XMLNode+Layout.swift
@@ -31,6 +31,17 @@ extension XMLNode {
         return true
     }
 
+    public var isMacro: Bool {
+        guard case .node("macro", _, _) = self else {
+            return false
+        }
+        return true
+    }
+
+    public var isParameterOrMacro: Bool {
+        return isParameter || isMacro
+    }
+
     public var parameters: [String: String] {
         var params = [String: String]()
         for child in children where child.isParameter {

--- a/LayoutTests/LayoutNodeTests.swift
+++ b/LayoutTests/LayoutNodeTests.swift
@@ -198,6 +198,14 @@ class LayoutNodeTests: XCTestCase {
         XCTAssertEqual((node.view as! UILabel).text, "Foo")
     }
 
+    func testMacroNameShadowsState() {
+        let xmlData = "<UIView name=\"{foo}\"><macro name=\"name\" value=\"name\"/><UILabel text=\"{name}\"/></UIView>".data(using: .utf8)!
+        let node = try! LayoutNode.with(xmlData: xmlData)
+        node.setState(["name": "Foo"])
+        node.update()
+        XCTAssertEqual((node.view.subviews[0] as! UILabel).text, "Foo")
+    }
+
     // MARK: update(with:)
 
     func testUpdateViewWithSameClass() {

--- a/LayoutToolTests/FormatterTests.swift
+++ b/LayoutToolTests/FormatterTests.swift
@@ -186,7 +186,7 @@ class FormatterTests: XCTestCase {
         XCTAssertEqual(try format(input), output)
     }
 
-    // MARK: Parameters
+    // MARK: Parameters and macros
 
     func testViewWithParameterAndChildren() {
         let input = "<Foo>\n\n    <Bar/>\n\n    <param name=\"baz\" type=\"String\"/>\n    <Baz/>\n\n</Foo>"
@@ -203,6 +203,12 @@ class FormatterTests: XCTestCase {
     func testViewWithMultipleParametersWithCommentsAndChildren() {
         let input = "<Foo>\n    <param name=\"foo\" type=\"String\"/>\n\n    <!-- bar -->\n    <param name=\"bar\" type=\"String\"/>\n    <param name=\"baz\" type=\"String\"/>\n\n    <Bar/>\n</Foo>"
         let output = "<Foo>\n    <param name=\"foo\" type=\"String\"/>\n\n    <!-- bar -->\n    <param name=\"bar\" type=\"String\"/>\n    <param name=\"baz\" type=\"String\"/>\n\n    <Bar/>\n</Foo>\n"
+        XCTAssertEqual(try format(input), output)
+    }
+
+    func testViewWithMacroAndChildren() {
+        let input = "<Foo>\n\n    <Bar/>\n\n    <macro name=\"baz\" value=\"5\"/>\n    <Baz/>\n\n</Foo>"
+        let output = "<Foo>\n    <macro name=\"baz\" value=\"5\"/>\n\n    <Bar/>\n    <Baz/>\n</Foo>\n"
         XCTAssertEqual(try format(input), output)
     }
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
     - [Composition](#composition)
     - [Templates](#templates)
     - [Parameters](#parameters)
+    - [Macros](#macros)
     - [Ignore File](#ignore-file)
 - [Example Projects](#example-projects)
     - [SampleApp](#sampleapp)
@@ -69,7 +70,7 @@
     - [Formatting](#formatting)
     - [Renaming](#renaming)
 - [Xcode Extension](#xcodeextension)
-	- [Installation](#installation-2)
+    - [Installation](#installation-2)
     - [Formatting](#formatting-1)
 - [FAQ](#faq)
 
@@ -197,8 +198,8 @@ class MyViewController: LayoutViewController {
 
         // Option 3 - load a layout asynchronously from an XML file URL
         self.loadLayout(withContentsOfURL: ... ) { error in
-	    	...   
-	    }
+            ...   
+        }
     }
 }
 ```
@@ -1649,7 +1650,7 @@ The `UIWebView.loadHTMLString()` method also accepts a `baseURL` parameter for r
 
 ```xml
 <UIWebView
-	baseURL="http://example.com"
+    baseURL="http://example.com"
     htmlString="&lt;img href=&quot;/someImage.jpg&quot;&gt;"
 />
 ```
@@ -1658,7 +1659,7 @@ If you need to adjust the content insets for the web view, you can do this via t
 
 ```xml
 <UIWebView
-	scrollView.contentInsetAdjustmentBehavior="never"
+    scrollView.contentInsetAdjustmentBehavior="never"
     scrollView.contentInset.bottom="safeAreaInsets.bottom"
     scrollView.scrollIndicatorInsets="scrollView.contentInset"
     request="..."
@@ -1671,7 +1672,7 @@ Layout supports `WKWebView` in the same way as `UIWebView`, by converting the va
 
 ```xml
 <WKWebView
-	readAccessURL="~/Documents"
+    readAccessURL="~/Documents"
     fileURL="~/Documents/homepage.html"
 />
 ```
@@ -2071,8 +2072,8 @@ extension MyView {
 
     open override class var intrinsicContentSize: CGSize {
         return CGSize(
-        	width: UIViewNoIntrinsicMetric,
-        	height: 40
+            width: UIViewNoIntrinsicMetric,
+            height: 40
         )
     }
 }
@@ -2115,9 +2116,9 @@ class MyView: UIView, LayoutLoading {
 
 ```xml
 <MyView>
-	<MyView>
-	    ...
-	</MyView>
+    <MyView>
+        ...
+    </MyView>
 </MyView>
 ``` 
 
@@ -2274,6 +2275,42 @@ You can set default values for parameters by defining a matching expression on t
     ...
 </UIView>
 ```
+
+
+## Macros
+
+Sometimes you will find yourself repeating the same expression multiple times in a given layout. For example, all the views may have the same width or height, or the same spacing relative to their siblings. For example:
+
+```xml
+<UIView>
+    <UILabel left="20" right="100% - 20" top="20" text="Foo"/>
+    <UILabel left="20" right="100% - 20" top="previous.bottom + 20" text="Bar"/>
+    <UILabel left="20" right="100% - 20" top="previous.bottom + 20" text="Baz"/>
+</UIView>
+```
+
+Although you can pass numeric values into your layout as constants, this doesn't work for expressions like "100%" or "previous.bottom", where the symbols being referenced are relative to the position of the node in the hierarchy, so the actual value will vary in each instance.
+
+Layout has a solution for this, in the form of *macros*. A macro is a reusable expression that you define inside your Layout template. Like parameters, macros can be referenced by any child of the node where they are defined, but *unlike* parameters they cannot be set or overridden externally, and their value is determined at the point of use, rather than relative to the node where they are defined.
+
+Using macros, we can change the example above to:
+
+ ```xml
+<UIView>
+    <macro name="SPACING" value="20"/>
+    <macro name="LEFT" value="SPACING"/>
+    <macro name="RIGHT" value="100% - SPACING"/>
+    <macro name="TOP" value="previous.bottom + SPACING"/>
+    
+    <UILabel left="LEFT" right="RIGHT" top="TOP" text="Foo"/>
+    <UILabel left="LEFT" right="RIGHT" top="TOP" text="Bar"/>
+    <UILabel left="LEFT" right="RIGHT" top="TOP" text="Baz"/>
+</UIView>
+```
+
+This eliminates the repetition, making the layout more DRY, and easier to refactor.
+
+Note the use of UPPERCASE names for the macros - this isn't required, but it's a good way to visually distinguish between macros and ordinary constants, parameters or state variables. It also avoids namespace collisions with existing view properties.
 
 
 ## Ignore File

--- a/SampleApp/Text.xml
+++ b/SampleApp/Text.xml
@@ -8,6 +8,8 @@
         scrollIndicatorInsets.bottom="safeAreaInsets.bottom"
         scrollIndicatorInsets.top="safeAreaInsets.top">
 
+        <macro name="SPACING" value="previous.bottom + 20"/>
+
         <UILabel
             backgroundColor="#0001"
             font="bold"
@@ -18,7 +20,7 @@
             font="italic"
             text="Center-aligned italic text"
             textAlignment="center"
-            top="previous.bottom + 20"
+            top="SPACING"
             width="100%"
         />
         <UILabel
@@ -26,7 +28,7 @@
             font="bold italic"
             text="Right-aligned bold italic text"
             textAlignment="right"
-            top="previous.bottom + 20"
+            top="SPACING"
             width="100%"
         />
         <UILabel
@@ -35,20 +37,20 @@
             left="50% - (width / 2)"
             numberOfLines="0"
             text="This text is left-aligned, but the paragraph itself is centered. It also uses a custom font"
-            top="previous.bottom + 20"
+            top="SPACING"
             width="50%"
         />
         <UILabel
             backgroundColor="#0001"
             text="This text is colored"
             textColor="#09f"
-            top="previous.bottom + 20"
+            top="SPACING"
         />
         <UILabel
             backgroundColor="#0001"
             lineBreakMode="byWordWrapping"
             numberOfLines="0"
-            top="previous.bottom + 20"
+            top="SPACING"
             width="100%">
 
             <p>
@@ -69,7 +71,7 @@
             font="body"
             numberOfLines="0"
             text="This text is using the 'body' UIFontTextStyle, and respects the user's dynamic font size setting"
-            top="previous.bottom + 20"
+            top="SPACING"
             width="100%"
         />
     </UIScrollView>


### PR DESCRIPTION
Sometimes you will find yourself repeating the same expression multiple times in a given layout. For example, all the views may have the same width or height, or the same spacing relative to their siblings. For example:

```xml
<UIView>
    <UILabel left="20" right="100% - 20" top="20" text="Foo"/>
    <UILabel left="20" right="100% - 20" top="previous.bottom + 20" text="Bar"/>
    <UILabel left="20" right="100% - 20" top="previous.bottom + 20" text="Baz"/>
</UIView>
```

Although you can pass numeric values into your layout as constants, this doesn't work for entire expressions like "100% - 20" or "previous.bottom + 20", where the symbols being referenced are relative to the position of the node in the hierarchy, so the actual value will vary in each instance.

Layout has a solution for this, in the form of *macros*. A macro is a reusable expression that you define inside your Layout template. Like parameters, macros can be referenced by any child of the node where they are defined, but *unlike* parameters they cannot be set or overridden externally, and their value is determined at the point of use, rather than relative to the node where they are defined.

Using macros, we can change the example above to:

 ```xml
<UIView>
	<macro name="SPACING" value="20"/>
	<macro name="LEFT" value="SPACING"/>
	<macro name="RIGHT" value="100% - SPACING"/>
	<macro name="TOP" value="previous.bottom + SPACING"/>
	
	<UILabel left="LEFT" right="RIGHT" top="TOP" text="Foo"/>
	<UILabel left="LEFT" right="RIGHT" top="TOP" text="Bar"/>
	<UILabel left="LEFT" right="RIGHT" top="TOP" text="Baz"/>
</UIView>
```

This eliminates the repetition, making the layout more DRY, and easier to refactor.

Note the use of UPPERCASE names for the macros - this isn't required, but it's a good way to visually distinguish between macros and ordinary constants, parameters or state variables. It also avoids namespace collisions with existing view properties.
