### PR TITLE
Find by ID

### DIFF
--- a/Layout/Layout+XML.swift
+++ b/Layout/Layout+XML.swift
@@ -102,6 +102,7 @@ extension Layout {
             }
         }
 
+        let id = try parseStringAttribute(for: "id")
         let outlet = try parseStringAttribute(for: "outlet")
         let xmlPath = try parseStringAttribute(for: "xml")
         let templatePath = try parseStringAttribute(for: "template")
@@ -116,6 +117,7 @@ extension Layout {
 
         self.init(
             className: className,
+            id: id,
             outlet: outlet,
             expressions: attributes,
             parameters: parameters,

--- a/Layout/Layout.swift
+++ b/Layout/Layout.swift
@@ -6,6 +6,7 @@ import Foundation
 // serialized layouts
 struct Layout {
     var className: String
+    var id: String?
     var outlet: String?
     var expressions: [String: String]
     var parameters: [String: RuntimeType]

--- a/Layout/LayoutLoader.swift
+++ b/Layout/LayoutLoader.swift
@@ -31,6 +31,7 @@ private extension Layout {
         }
         return Layout(
             className: layout.className,
+            id: layout.id ?? id,
             outlet: layout.outlet ?? outlet,
             expressions: expressions,
             parameters: parameters,

--- a/Layout/LayoutNode+Layout.swift
+++ b/Layout/LayoutNode+Layout.swift
@@ -16,6 +16,7 @@ extension LayoutNode {
         }
         try self.init(
             class: layout.getClass(),
+            id: layout.id,
             outlet: outlet ?? layout.outlet,
             state: state,
             constants: merge(constants),
@@ -57,6 +58,7 @@ extension Layout {
     init(_ node: LayoutNode) {
         self.init(
             className: NSStringFromClass(node._class),
+            id: node.id,
             outlet: node.outlet,
             expressions: node._originalExpressions,
             parameters: node._parameters,

--- a/Layout/LayoutNode.swift
+++ b/Layout/LayoutNode.swift
@@ -39,6 +39,9 @@ public class LayoutNode: NSObject {
     /// The name of an outlet belonging to the nodes' owner that the node should bind to
     public private(set) var outlet: String?
 
+    /// The node identifier, which can be used to refer to the node from within an expression
+    public private(set) var id: String?
+
     /// The expressions used to initialized the node
     public private(set) var expressions: [String: String]
 
@@ -208,6 +211,7 @@ public class LayoutNode: NSObject {
     // TODO: is there any reason not to make this public?
     init(
         class: AnyClass,
+        id: String? = nil,
         outlet: String? = nil,
         state: Any = (),
         constants: [String: Any]...,
@@ -219,6 +223,7 @@ public class LayoutNode: NSObject {
         }
         _class = `class`
         _state = try! unwrap(state)
+        self.id = id
         self.outlet = outlet
         self.constants = merge(constants)
         self.expressions = expressions
@@ -250,6 +255,7 @@ public class LayoutNode: NSObject {
     /// Create a node for managing a view controller instance
     public convenience init(
         viewController: UIViewController,
+        id: String? = nil,
         outlet: String? = nil,
         state: Any = (),
         constants: [String: Any]...,
@@ -260,6 +266,7 @@ public class LayoutNode: NSObject {
 
         try! self.init(
             class: viewController.classForCoder,
+            id: id,
             outlet: outlet,
             state: state,
             constants: merge(constants),
@@ -274,6 +281,7 @@ public class LayoutNode: NSObject {
     /// Create a node for managing a view instance
     public convenience init(
         view: UIView? = nil,
+        id: String? = nil,
         outlet: String? = nil,
         state: Any = (),
         constants: [String: Any]...,
@@ -284,6 +292,7 @@ public class LayoutNode: NSObject {
 
         try! self.init(
             class: view?.classForCoder ?? UIView.self,
+            id: id,
             outlet: outlet,
             state: state,
             constants: merge(constants),
@@ -509,6 +518,22 @@ public class LayoutNode: NSObject {
         if let siblings = parent?.children, let index = siblings.index(where: { $0 === self }),
             index < siblings.count - 1 {
             return siblings[index + 1]
+        }
+        return nil
+    }
+
+    // Find a node by id, starting with the children and then progressing to siblings and parents
+    private func node(forID id: String, excluding: LayoutNode? = nil) -> LayoutNode? {
+        if self.id == id {
+            return self
+        }
+        for child in children where child !== excluding {
+            if let match = child.node(forID: id, excluding: self) {
+                return match
+            }
+        }
+        if parent != excluding {
+            return parent?.node(forID: id, excluding: self)
         }
         return nil
     }
@@ -1276,6 +1301,17 @@ public class LayoutNode: NSObject {
                 case "strings":
                     getter = { [unowned self] in
                         try self.value(forParameterOrVariableOrConstant: symbol) ?? self.localizedString(forKey: tail)
+                    }
+                case let head where head.hasPrefix("#"):
+                    let id = String(head.characters.dropFirst())
+                    if let node = self.node(forID: id) {
+                        getter = { [unowned node] in
+                            try node.value(forSymbol: tail) as Any
+                        }
+                    } else {
+                        getter = {
+                            throw SymbolError("Could not find node with id `\(id)`", for: symbol)
+                        }
                     }
                 default:
                     getter = getterFor(symbol)

--- a/LayoutTool/Common.swift
+++ b/LayoutTool/Common.swift
@@ -255,7 +255,7 @@ func isStringType(_ name: String) -> Bool {
 func typeOfAttribute(_ key: String, inNode node: XMLNode) -> String? {
     func typeForClass(_ className: String) -> String? {
         switch key {
-        case "outlet":
+        case "outlet", "id":
             return "String"
         case "xml", "template":
             return "URL"

--- a/README.md
+++ b/README.md
@@ -610,7 +610,36 @@ a >= b ? a : b
 pi / 2
 ```
 
-Additionally, a node can reference properties of its parent node using `parent.someProperty`, or of its immediate sibling nodes using `previous.someProperty` and `next.someProperty`.
+Additionally, a node can reference properties of its parent node using `parent.someProperty`, or of its immediate sibling nodes using `previous.someProperty` and `next.someProperty`:
+
+```xml
+<UIView>
+    <UILabel text="Foo"/>
+    
+    <!-- this label will be 20pts below its previous sibling -->
+    <UILabel
+        top="previous.bottom + 20"
+        text="Bar"
+    />
+</UIView>
+```
+
+To reference a node that is not an immediate sibling, you can give the node an `id` attribute, and then reference that node using `#` followed by the id:
+
+```xml
+<UIView>
+    <UILabel id="first" left="20" text="Foo"/>
+    <UILabel right="20" text="Bar"/>
+    
+    <!-- this label will be aligned with the first label -->
+    <UILabel
+        left="#first.left"
+        top="previous.bottom + 20"
+        text="Bar"
+    />
+</UIView>
+```
+
 
 ## Layout Properties
 
@@ -2436,7 +2465,7 @@ When you have a Layout XML file open in Xcode, select the `Editor > Layout > For
 
 *Q. Which platforms are supported?*
 
-> Layout works on iOS 9.0 and above. There is currently no support for other Apple OSes (tvOS, watchOS, macOS), nor cometing platforms such as Android or Windows.
+> Layout works on iOS 9.0 and above. There is currently no support for other Apple OSes (tvOS, watchOS, macOS), nor competing platforms such as Android or Windows.
 
 *Q. Will Layout ever support watchOS/tvOS?*
 

--- a/SampleApp/Boxes.xml
+++ b/SampleApp/Boxes.xml
@@ -15,6 +15,7 @@
         <UIView
             backgroundColor="colors.red"
             height="width"
+            id="first"
             transform.rotation="isToggled ? pi / 2 : 0"
             width="isToggled ? (100% - 15) / 2 : (100% - (15 * 2)) / 3"
         />
@@ -36,7 +37,7 @@
             backgroundColor="colors.blue"
             height="width / 2"
             left="width + 15"
-            width="isToggled ? (100% - 15) / 2 : (100% - (15 * 2)) / 3"
+            width="#first.width"
         />
         <UIView
             backgroundColor="colors.green"


### PR DESCRIPTION
This PR adds the ability to reference any Layout node by ID from within an expression, instead of just the immediate siblings or parent of the expressions's node.

Example:

```xml
<UIView>
    <UILabel id="first" left="20" text="Foo"/>
    <UILabel right="20" text="Bar"/>
    
    <!-- this label will be aligned with the first label -->
    <UILabel
        left="#first.left"
        top="previous.bottom + 20"
        text="Bar"
    />
</UIView>
```

Why add a new `id` attribute instead of using the existing `outlet`? Because outlets must correspond to real Swift properties in code, and you may want to reference nodes in the template without referencing them in Swift.

Why the `#` prefix? This helps avoid namespace collisions with other properties, and is an established convention for referencing specific XML or HTML document nodes in a URL or CSS selector.

Doesn't the `#` prefix clash with hex color literals? In practice, not really. Hex color literals can only be used inside a color expression, and cannot contain a `.`, so an expression like `backgroundColor="#fab.backgroundColor"` would be fine because even though `#fab` would be interpreted as a color literal on its own, the `.` causes it to be treated as a node id instead.