### PR TITLE
Added layoutDidLoad(_ layoutNode: LayoutNode)

### DIFF
--- a/Layout.xcodeproj/project.pbxproj
+++ b/Layout.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		0105F78A1F0547910067B313 /* LayoutError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F77D1F0547910067B313 /* LayoutError.swift */; };
 		0105F78B1F0547910067B313 /* LayoutExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F77E1F0547910067B313 /* LayoutExpression.swift */; };
 		0105F78C1F0547910067B313 /* LayoutLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F77F1F0547910067B313 /* LayoutLoader.swift */; };
-		0105F78D1F0547910067B313 /* LayoutLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F7801F0547910067B313 /* LayoutLoading.swift */; };
 		0105F78E1F0547910067B313 /* LayoutNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F7811F0547910067B313 /* LayoutNode.swift */; };
 		0105F78F1F0547910067B313 /* LayoutNode+XML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F7821F0547910067B313 /* LayoutNode+XML.swift */; };
 		0105F7901F0547910067B313 /* LayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F7831F0547910067B313 /* LayoutViewController.swift */; };
@@ -157,6 +156,10 @@
 		01FAAD271FBD991E00C26799 /* StackViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FAAD261FBD991E00C26799 /* StackViewTests.swift */; };
 		3583485A1F3F1EB000CFB6BB /* ReturnCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358348591F3F1EB000CFB6BB /* ReturnCodeTests.swift */; };
 		3583485B1F3F217200CFB6BB /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F79C1F055C260067B313 /* main.swift */; };
+		ACD6CEF01FD6ABC900E08B8C /* LayoutViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD6CEEF1FD6ABC900E08B8C /* LayoutViewControllerTests.swift */; };
+		ACD6CEF31FD6AFC400E08B8C /* LayoutDidLoad_Valid.xml in Resources */ = {isa = PBXBuildFile; fileRef = ACD6CEF21FD6AFC400E08B8C /* LayoutDidLoad_Valid.xml */; };
+		ACD6CEF51FD6B16F00E08B8C /* LayoutLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105F7801F0547910067B313 /* LayoutLoading.swift */; };
+		ACD6CEF71FD6C64A00E08B8C /* LayoutDidLoad_Invalid.xml in Resources */ = {isa = PBXBuildFile; fileRef = ACD6CEF61FD6C64A00E08B8C /* LayoutDidLoad_Invalid.xml */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -402,6 +405,9 @@
 		4118130BF7EC77593CF35CF1 /* Pods_Layout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Layout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		53F1B12A3E800D0CF1C1C2D3 /* Pods_UIDesigner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UIDesigner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8470F0AD644C109EF8FEA9C4 /* Pods_SampleApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SampleApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ACD6CEEF1FD6ABC900E08B8C /* LayoutViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutViewControllerTests.swift; sourceTree = "<group>"; };
+		ACD6CEF21FD6AFC400E08B8C /* LayoutDidLoad_Valid.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = LayoutDidLoad_Valid.xml; sourceTree = "<group>"; };
+		ACD6CEF61FD6C64A00E08B8C /* LayoutDidLoad_Invalid.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = LayoutDidLoad_Invalid.xml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -622,6 +628,7 @@
 		011CE6AE1F053D090034771C /* LayoutTests */ = {
 			isa = PBXGroup;
 			children = (
+				ACD6CEF11FD6AF8900E08B8C /* ViewController */,
 				01345C541F66B784002BDEC9 /* PropertiesTests.swift */,
 				011CE6B91F053D530034771C /* AnyExpressionTests.swift */,
 				011CE6BA1F053D530034771C /* ColorExpressionTests.swift */,
@@ -785,6 +792,16 @@
 				01EAFD781F60613600B73E92 /* Info.plist */,
 			);
 			path = UIKitSymbols;
+			sourceTree = "<group>";
+		};
+		ACD6CEF11FD6AF8900E08B8C /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				ACD6CEEF1FD6ABC900E08B8C /* LayoutViewControllerTests.swift */,
+				ACD6CEF21FD6AFC400E08B8C /* LayoutDidLoad_Valid.xml */,
+				ACD6CEF61FD6C64A00E08B8C /* LayoutDidLoad_Invalid.xml */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1179,6 +1196,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ACD6CEF31FD6AFC400E08B8C /* LayoutDidLoad_Valid.xml in Resources */,
+				ACD6CEF71FD6C64A00E08B8C /* LayoutDidLoad_Invalid.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1353,7 +1372,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0105F78D1F0547910067B313 /* LayoutLoading.swift in Sources */,
 				01E7E0511F1C077900B7F9DB /* LayoutError+LayoutNode.swift in Sources */,
 				01E7E04F1F1C057700B7F9DB /* Layout+XML.swift in Sources */,
 				012073261F39EE0000FD092A /* UIScrollView+Layout.swift in Sources */,
@@ -1374,6 +1392,7 @@
 				0105F7891F0547910067B313 /* AnyExpression.swift in Sources */,
 				013A91AD1FC729090043C543 /* Expression.swift in Sources */,
 				0105F78C1F0547910067B313 /* LayoutLoader.swift in Sources */,
+				ACD6CEF51FD6B16F00E08B8C /* LayoutLoading.swift in Sources */,
 				0105F7951F0547910067B313 /* UIViewController+Layout.swift in Sources */,
 				015681081F6BE7B20038B7BB /* CALayer+Layout.swift in Sources */,
 				011D73611FB1B7DE006406F7 /* LayoutBacked.swift in Sources */,
@@ -1397,6 +1416,7 @@
 			files = (
 				011CE6C31F053D530034771C /* AnyExpressionTests.swift in Sources */,
 				011CE6C41F053D530034771C /* ColorExpressionTests.swift in Sources */,
+				ACD6CEF01FD6ABC900E08B8C /* LayoutViewControllerTests.swift in Sources */,
 				0192A6D51FA7A7D400A30FDA /* AttributedStringExpressionTests.swift in Sources */,
 				013A91B31FC72ED50043C543 /* StringConstantTests.swift in Sources */,
 				011CE6C61F053D530034771C /* FontExpressionTests.swift in Sources */,

--- a/Layout/LayoutViewController.swift
+++ b/Layout/LayoutViewController.swift
@@ -18,7 +18,7 @@ open class LayoutViewController: UIViewController, LayoutLoading {
                 do {
                     try layoutNode.mount(in: self)
                     if _error == nil {
-                        layoutDidLoad()
+                        layoutDidLoad(layoutNode)
                     }
                 } catch {
                     layoutError(LayoutError(error, for: layoutNode))
@@ -56,6 +56,14 @@ open class LayoutViewController: UIViewController, LayoutLoading {
 
     /// Called immediately after the layoutNode is set. Will not be called
     /// in the event of an error, or if layoutNode is set to nil
+    open func layoutDidLoad(_ layoutNode: LayoutNode) {
+        // Mimic old behaviour if not overriden
+        layoutDidLoad()
+    }
+
+    /// Called immediately after the layoutNode is set. Will not be called
+    /// in the event of an error, or if layoutNode is set to nil
+    @available(*, deprecated, message: "Use layoutDidLoad(_ layoutNode:) instead")
     open func layoutDidLoad() {
         // Override in subclass
     }

--- a/LayoutTests/ViewController/LayoutDidLoad_Invalid.xml
+++ b/LayoutTests/ViewController/LayoutDidLoad_Invalid.xml
@@ -1,0 +1,3 @@
+<UIView>
+    <THIS IS INVALID XML
+</UIView>

--- a/LayoutTests/ViewController/LayoutDidLoad_Valid.xml
+++ b/LayoutTests/ViewController/LayoutDidLoad_Valid.xml
@@ -1,0 +1,2 @@
+<UIView>
+</UIView>

--- a/LayoutTests/ViewController/LayoutViewControllerTests.swift
+++ b/LayoutTests/ViewController/LayoutViewControllerTests.swift
@@ -1,0 +1,70 @@
+//  Copyright © 2017 Schibsted. All rights reserved.
+
+import XCTest
+@testable import Layout
+
+class LayoutViewControllerTests: XCTestCase {
+
+    /// Test class for layoutDidLoad() backward compatibility test
+    class BackwardTestLayoutViewController: LayoutViewController {
+
+        var layoutDidLoadCallCount = 0
+
+        override func layoutDidLoad() {
+            layoutDidLoadCallCount += 1
+        }
+    }
+
+    /// Test class which overrides layoutDidLoad(_:)
+    class TestLayoutViewController: BackwardTestLayoutViewController {
+
+        var layoutDidLoadLayoutNode: LayoutNode?
+        var layoutDidLoadLayoutNodeCallCount = 0
+
+        override func layoutDidLoad(_ layoutNode: LayoutNode) {
+            layoutDidLoadLayoutNodeCallCount += 1
+            layoutDidLoadLayoutNode = layoutNode
+        }
+    }
+
+    func testLayoutDidLoadWithValidXML() throws {
+        let viewController = TestLayoutViewController()
+        viewController.loadLayout(withContentsOfURL: try url(forXml: "LayoutDidLoad_Valid"))
+
+        XCTAssertNotNil(viewController.layoutDidLoadLayoutNode)
+        XCTAssertEqual(viewController.layoutNode, viewController.layoutDidLoadLayoutNode)
+        XCTAssertEqual(viewController.layoutDidLoadLayoutNodeCallCount, 1)
+        XCTAssertEqual(viewController.layoutDidLoadCallCount, 0)
+    }
+
+    func testLayoutDidLoadWithInvalidXML() throws {
+        let viewController = TestLayoutViewController()
+        viewController.loadLayout(withContentsOfURL: try url(forXml: "LayoutDidLoad_Invalid"))
+
+        XCTAssertNil(viewController.layoutDidLoadLayoutNode)
+        XCTAssertEqual(viewController.layoutDidLoadLayoutNodeCallCount, 0)
+        XCTAssertEqual(viewController.layoutDidLoadCallCount, 0)
+    }
+
+    func testCompatibilityLayoutDidLoadWithValidXML() throws {
+        let viewController = BackwardTestLayoutViewController()
+        viewController.loadLayout(withContentsOfURL: try url(forXml: "LayoutDidLoad_Valid"))
+
+        XCTAssertEqual(viewController.layoutDidLoadCallCount, 1)
+    }
+
+    func testCompatibilityLayoutDidLoadWithInvalidXML() throws {
+        let viewController = BackwardTestLayoutViewController()
+        viewController.loadLayout(withContentsOfURL: try url(forXml: "LayoutDidLoad_Invalid"))
+
+        XCTAssertEqual(viewController.layoutDidLoadCallCount, 0)
+    }
+
+    private func url(forXml name: String) throws -> URL {
+        guard let url = Bundle(for: LayoutViewControllerTests.self).url(forResource: name, withExtension: "xml") else {
+            throw NSError(domain: "Could not find the following test resource: \(name).xml", code: 0)
+        }
+
+        return url
+    }
+}

--- a/SampleApp/ExamplesViewController.swift
+++ b/SampleApp/ExamplesViewController.swift
@@ -37,14 +37,13 @@ class ExamplesViewController: LayoutViewController, UITabBarControllerDelegate {
         )
     }
 
-    override var layoutNode: LayoutNode? {
-        didSet {
-            guard let tabBarController = layoutNode?.viewController as? UITabBarController else {
-                return
-            }
-            tabBarController.selectedIndex = selectedTab
-            tabBarController.delegate = self
+    override func layoutDidLoad(_ layoutNode: LayoutNode) {
+        guard let tabBarController = layoutNode.viewController as? UITabBarController else {
+            return
         }
+
+        tabBarController.selectedIndex = selectedTab
+        tabBarController.delegate = self
     }
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {


### PR DESCRIPTION
Deprecates the parameterless layoutDidLayout. See #86 