### PR TITLE
Make background less aggressive

### DIFF
--- a/Layout/LayoutConsole.swift
+++ b/Layout/LayoutConsole.swift
@@ -130,7 +130,7 @@ private class LayoutErrorView: UIView, LayoutLoading {
                 )
             }
         default:
-            background = "red"
+            background = "#D32F2F"
             let suggestions = error.suggestions
             if suggestions.count == 1 {
                 message += "\n\nDid you mean `\(suggestions[0])`?"


### PR DESCRIPTION
Make red less aggressive for more comfortable reading available attributes.
`#D32F2F` is Red 700.

![](https://simplecat.tk/shots/shot-20180215-215641.png)