### PR TITLE
Update podspec to include correct sources only

### DIFF
--- a/Layout.podspec.json
+++ b/Layout.podspec.json
@@ -16,7 +16,7 @@
   "subspecs": [
     {
       "name": "Core",
-      "source_files": "Layout/**/*"
+      "source_files": "Layout/**/*.swift"
     },
     {
       "name": "CLI",


### PR DESCRIPTION
When using CocoaPods 1.4.0 and XCode 9 new build system, there's a problem because `Info.plist` gets included in the compiled files. XCode build graph won't build unless the file is excluded.

I've update the podspec to include `.swift` files only.