### PR TITLE
use ivar instead of getter of viewController

### DIFF
--- a/Layout/LayoutNode.swift
+++ b/Layout/LayoutNode.swift
@@ -29,7 +29,7 @@ public class LayoutNode: NSObject {
     /// These should be added as child view controllers to the node's parent view controller
     /// Accessing this property will instantiate the view hierarchy if it doesn't already exist
     public var viewControllers: [UIViewController] {
-        guard let viewController = viewController else {
+        guard let viewController = _viewController else {
             return children.flatMap { $0.viewControllers }
         }
         return [viewController]


### PR DESCRIPTION
```
public extension LayoutLoading where Self: UIViewController {
    /// Default layoutNode implementation for view controllers
    var layoutNode: LayoutNode? {
        get {
            return objc_getAssociatedObject(self, &layoutNodeKey) as? LayoutNode
        }
        set {
            layoutNode?.unmount()
            objc_setAssociatedObject(self, &layoutNodeKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
            layoutNode?.unmount()
            if let layoutNode = layoutNode {
                do {
                    try layoutNode.mount(in: self)
                    layoutDidLoad(layoutNode)
                } catch {
                    layoutError(LayoutError(error, for: layoutNode))
                }
            }
        }
    }
}
```

second unmount() calls viewControllers

```
    public func unmount() {
        guard parent == nil else {
            // If not a root node, treat the same as `removeFromParent()`
            // TODO: should this be an error instead?
            removeFromParent()
            return
        }
        unbind()
        for controller in viewControllers {
            controller.removeFromParent()
        }
        _view?.removeFromSuperview()
    }
```

```
    public var viewControllers: [UIViewController] {
        guard let viewController = viewController else {
            return children.flatMap { $0.viewControllers }
        }
        return [viewController]
    }
```
which calls setUpExpressions() even before mount(in:) calls.

```
    public var viewController: UIViewController? {
        if _class is UIViewController.Type {
            attempt(setUpExpressions)
        }
        return _viewController
    }
```
